### PR TITLE
Added Master API Key Setting

### DIFF
--- a/language/de.json
+++ b/language/de.json
@@ -2,7 +2,9 @@
     "acd.ta": {
         "settings": {
             "ApiKey": "API-Key",
-            "ApiKeyHint":"Dein API Key von Elevenlabs"
+            "ApiKeyHint":"Dein API Key von Elevenlabs",
+            "MasterApiKey": "Haupt-API-Key",
+            "MasterApiKeyHint":"Der Elevenlabs API Key, der von allen Clients genutzt wird, für die kein eigenen API Key angegeben wurde. Lasse ihn frei, wenn Du Deinen Elevenlabs Account nicht mit deinen Spielern teilen möchtest."
         },
         "controls": {
             "button.title": "Stimmeinstellungen"

--- a/language/en.json
+++ b/language/en.json
@@ -2,7 +2,9 @@
     "acd.ta": {
         "settings": {
             "ApiKey": "API-Key",
-            "ApiKeyHint":"Your Elevenlabs API Key"
+            "ApiKeyHint":"Your Elevenlabs API Key",
+            "MasterApiKey": "Master-API-Key",
+            "MasterApiKeyHint":"The Elevenlabs API Key to be used by all clients without their own API-Key. Leave empty when yoe don't want to share your Elevenlabs Account with your players."
         },
         "controls": {
             "button.title": "Voice Settings"

--- a/scripts/ElevenlabsApi/ElevenlabsRequests.js
+++ b/scripts/ElevenlabsApi/ElevenlabsRequests.js
@@ -6,6 +6,9 @@ class ElevenlabsRequest {
 
     constructor() {
         this.api_key = game.settings.get(MODULE.ID, MODULE.APIKEY);
+        if (this.api_key?.length <1) {
+            this.api_key = game.settings.get(MODULE.ID, MODULE.MASTERAPIKEY);
+        }
     }
 
     execute() {

--- a/scripts/ElevenlabsConnector.js
+++ b/scripts/ElevenlabsConnector.js
@@ -7,14 +7,15 @@ export class ElevenlabsConnector {
     allVoices;
 
     async initializeMain() {
-        if (this.HasApiKey) {
+        if (this.hasApiKey()) {
             await this.getVoices();
             await this.getUserdata();
         }
     }
 
-    HasApiKey() {
-        return game.settings.get(MODULE.ID, MODULE.APIKEY) != undefined;
+    hasApiKey() {
+        return (game.settings.get(MODULE.ID, MODULE.APIKEY)?.length > 1)
+              || (game.settings.get(MODULE.ID, MODULE.MASTERAPIKEY)?.length > 1);
     }
 
     processChatMessage(chatlog, messageText, chatData) {
@@ -28,7 +29,7 @@ export class ElevenlabsConnector {
 
         messageText = messageData[2];
 
-        if (!this.HasApiKey) {
+        if (!this.hasApiKey()) {
             ui.notifications.error(localize("acd.ta.errors.noApiKey"));
             return false;
         }

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -6,7 +6,8 @@ export const MODULE = {
     NAME: 'Talking Actors',
     DIR: 'modules/acd-talking-actors/',
     TEMPLATEDIR: 'modules/acd-talking-actors/templates/',
-    APIKEY: "xi-api-key"
+    APIKEY: "xi-api-key",
+    MASTERAPIKEY: "xi-master-api-key"
 }
 
 export const FLAGS = {

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -8,6 +8,16 @@ export let localize = key => {
 
 Hooks.once("init", async function () {
 
+    game.settings.register(MODULE.ID, MODULE.MASTERAPIKEY, {
+        name: localize("acd.ta.settings.MasterApiKey"),
+        hint: localize("acd.ta.settings.MasterApiKeyHint"),
+        scope: "world",
+        config: true,
+        type: String,
+        onChange: value => { game.talkingactors.connector.initializeMain() },
+        requiresReload: true 
+    });
+
     game.settings.register(MODULE.ID, MODULE.APIKEY, {
         name: localize("acd.ta.settings.ApiKey"),
         hint: localize("acd.ta.settings.ApiKeyHint"),


### PR DESCRIPTION
An optional master API key for elevenlabs can now be specified. The master key will be used by all clients without an own API-Key setting.