### PR TITLE
Feature-Request: Audio Only - no text in chat #33

### DIFF
--- a/language/de.json
+++ b/language/de.json
@@ -10,7 +10,9 @@
             "AllowUsers": "Benutzer erlaubt",
             "AllowUsersHint": "Ist diese Option aktiv, haben Benutzer, die kein Spielleiter sind, Zugriff auf dieses Modul.",
             "EnableSelectionContextMenu": "Aktiviere Kontextmenü für ausgewählten Text",
-            "EnableSelectionContextMenuHint": "Wenn diese Option aktiviert ist, wird in Journaleinträgen ein Kontextmenü angezeigt, um die ausgewählten Textteile vorzulesen. (Nicht kompatibel mit dem Modul \"Narrator Tools\")"
+            "EnableSelectionContextMenuHint": "Wenn diese Option aktiviert ist, wird in Journaleinträgen ein Kontextmenü angezeigt, um die ausgewählten Textteile vorzulesen. (Nicht kompatibel mit dem Modul \"Narrator Tools\")",
+            "PostTextToChat": "Schicke den gesprochenen Text in den Chat",
+            "PostTextToChatHint": "Wenn diese Option aktiviert ist, wird der gesprochene Text in das Chatwindow geschrieben (und möglicherweise als Sprechblase über dem Token des Akteurs angezeigt)."
         },
         "controls": {
             "button.title": "Stimmeinstellungen",

--- a/language/en.json
+++ b/language/en.json
@@ -10,7 +10,9 @@
             "AllowUsers": "Allow users",
             "AllowUsersHint": "If enabled, users have access to the module.",
             "EnableSelectionContextMenu": "Enable Context Menu On Selected Text",
-            "EnableSelectionContextMenuHint": "If enabled, a context menu will be presented in journal entries to read aloud the selected text parts. (Not compatible with the module \"Narrator Tools\""
+            "EnableSelectionContextMenuHint": "If enabled, a context menu will be presented in journal entries to read aloud the selected text parts. (Not compatible with the module \"Narrator Tools\"",
+            "PostTextToChat": "Post spoken text to chat",
+            "PostTextToChatHint": "If enabled, the spoken text will be posted to the chat window (and possibly as a chat bubble on the actor's token)"
         },
         "controls": {
             "button.title": "Voice Settings",

--- a/scripts/ElevenlabsApi/ElevenlabsRequests.js
+++ b/scripts/ElevenlabsApi/ElevenlabsRequests.js
@@ -69,7 +69,7 @@ export class TextToSpeechRequest extends ElevenlabsRequest {
         };
 
         if (this.settings) {
-            body = mergeObject(body, {
+            body = foundry.utils.mergeObject(body, {
                 "voice_settings": {
                     "stability": this.settings.stability,
                     "similarity_boost": this.settings.similarity_boost,

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -10,7 +10,8 @@ export const MODULE = {
     MASTERAPIKEY: "xi-master-api-key",
     NARRATORACTOR: "narrating-actor",
     ALLOWUSERS: "allow-users",
-    ENABLESELECTIONCONTEXTMENU: "enableContextMenuOnSelection"
+    ENABLESELECTIONCONTEXTMENU: "enableContextMenuOnSelection",
+    POSTTOCHAT: "postSpokenTextToChat"
 }
 
 export const FLAGS = {

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -55,6 +55,17 @@ function registerSettings() {
         type: Boolean,
         default: false,
     });
+
+    
+    game.settings.register(MODULE.ID, MODULE.POSTTOCHAT, {
+        name: 'acd.ta.settings.PostTextToChat',
+        hint: 'acd.ta.settings.PostTextToChatHint',
+        config: true,
+        scope: 'world',
+        type: Boolean,
+        default: true,
+    });
+
 }
 
 function isModuleAccessible() {


### PR DESCRIPTION
- Added configuration setting to enable or disable chat output for spoken text.
- Added chat command "/talk-s" to speak text without chat output (is overridden by the configuration setting)